### PR TITLE
Improved tag delete and enforced unique names

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -377,7 +377,9 @@ class Tag(Model):
 
     __tablename__ = 'tags'
     id = Column(Integer, primary_key=True)
-    tag_name = Column(String(255))
+    __table_args__ = (UniqueConstraint('tag_name'),)
+
+    tag_name = Column(String(255), unique=True)
 
     def __repr__(self):
         return self.tag_name
@@ -398,7 +400,7 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
         'Slice', secondary=dashboard_slices, backref='dashboards')
     owners = relationship(security_manager.user_model, secondary=dashboard_user)
     tags = relationship(
-        'Tag', secondary=dashboard_tags)
+        'Tag', secondary=dashboard_tags, backref='dashboards')
 
     export_fields = ('dashboard_title', 'position_json', 'json_metadata',
                      'description', 'css', 'slug')

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -542,6 +542,37 @@ class SliceAddView(SliceModelView):  # noqa
 appbuilder.add_view_no_menu(SliceAddView)
 
 
+class TagModelView(SupersetModelView, DeleteMixin):
+    datamodel = SQLAInterface(models.Tag)
+
+    list_title = _('List Tag')
+    show_title = _('Show Tag')
+    add_title = _('Add Tag')
+    edit_title = _('Edit Tag')
+
+    list_columns = ['tag_name']
+    edit_columns = ['tag_name']
+
+    add_columns = edit_columns
+
+    label_columns = {
+        'tag_name': _('Tag Name'),
+    }
+
+    def pre_delete(self, obj):
+        pass
+
+
+appbuilder.add_view(
+    TagModelView,
+    'Tags',
+    label=__('Tags'),
+    icon='fa-tags',
+    category='Manage',
+    category_label=__('Manage'),
+    category_icon='')
+
+
 class DashboardModelView(SupersetModelView, DeleteMixin):  # noqa
     route_base = '/dashboard'
     datamodel = SQLAInterface(models.Dashboard)
@@ -2128,6 +2159,7 @@ class Superset(BaseSupersetView):
         dash_save_perm = security_manager.can_access('can_save_dash', 'Superset')
         superset_can_explore = security_manager.can_access('can_explore', 'Superset')
         slice_can_edit = security_manager.can_access('can_edit', 'SliceModelView')
+        tag_can_edit = security_manager.can_access('can_edit', 'TagModelView')
 
         standalone_mode = request.args.get('standalone') == 'true'
         edit_mode = request.args.get('edit') == 'true'
@@ -2149,6 +2181,7 @@ class Superset(BaseSupersetView):
             'dash_edit_perm': dash_edit_perm,
             'superset_can_explore': superset_can_explore,
             'slice_can_edit': slice_can_edit,
+            'tag_can_edit': tag_can_edit,
         })
 
         bootstrap_data = {

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -560,7 +560,19 @@ class TagModelView(SupersetModelView, DeleteMixin):
     }
 
     def pre_delete(self, obj):
-        pass
+        current_tag_id = obj.id
+        qry = (
+	    db.session.query(
+	        models.dashboard_tags
+	    )
+	    .filter_by(
+	        tag_id=current_tag_id
+            )
+	    .count()
+	)
+        if qry > 0:
+            raise SupersetException(Markup(
+                'Cannot delete a tag that has {} dashboard(s) attached.'.format(qry)))
 
 
 appbuilder.add_view(


### PR DESCRIPTION
- Added an exception that you can't delete a tag if there are dashboards associated with it
- Enforced unique constraint on tag name (although right now it's case sensitive i.e. Tag and tag can both exist)
- Added a backref to dashboard for Tag

Tested by deleting:
- Tag with no dashboard attached (successful deletion, expected behavior)
- Tag with 1 dashboard attached (exception thrown, expected behavior)
- Tag with 1+ (2) dashboards attached (exception thrown, expected behavior)

<img width="1792" alt="screen shot 2019-01-18 at 9 51 46 pm" src="https://user-images.githubusercontent.com/8509202/51421415-15f05280-1b6c-11e9-9d69-65c81c3d0263.png">
<img width="1792" alt="screen shot 2019-01-18 at 9 51 31 pm" src="https://user-images.githubusercontent.com/8509202/51421416-15f05280-1b6c-11e9-89db-8b154bf172b5.png">
<img width="1792" alt="screen shot 2019-01-18 at 9 51 15 pm" src="https://user-images.githubusercontent.com/8509202/51421417-15f05280-1b6c-11e9-926d-b95cfa328d6e.png">
